### PR TITLE
Add basic initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-scm
+
+# gcc for cgo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY gimme /usr/local/bin/
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH


### PR DESCRIPTION
This is based heavily on https://github.com/docker-library/golang/blob/a4f3927494b48c7bdb6ea6edac8f89818853b45b/1.5/Dockerfile.

Example usage:

``` console
$ docker build -t travisci/gimme .
...
$ docker run -it --rm travisci/gimme
root@a42cc34ff47e:/go# eval "$(gimme 1.4.3)"
go version go1.4.3 linux/amd64
root@a42cc34ff47e:/go# go get -v github.com/tianon/gosu/...
github.com/tianon/gosu (download)
github.com/docker/libcontainer (download)
github.com/docker/libcontainer/system
github.com/docker/libcontainer/user
github.com/tianon/gosu
root@a42cc34ff47e:/go# gosu www-data id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
