### PR TITLE
Use existing source version if possible

### DIFF
--- a/gimme
+++ b/gimme
@@ -282,8 +282,20 @@ _env_alias() {
 }
 
 _try_existing() {
-	local existing_ver="${GIMME_VERSION_PREFIX}/go${GIMME_GO_VERSION}.${GIMME_OS}.${GIMME_ARCH}"
-	local existing_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.${GIMME_OS}.${GIMME_ARCH}.env"
+	case "${1}" in
+		binary)
+			local existing_ver="${GIMME_VERSION_PREFIX}/go${GIMME_GO_VERSION}.${GIMME_OS}.${GIMME_ARCH}"
+			local existing_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.${GIMME_OS}.${GIMME_ARCH}.env"
+			;;
+		source)
+			local existing_ver="${GIMME_VERSION_PREFIX}/go${GIMME_GO_VERSION}.src"
+			local existing_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.src.env"
+			;;
+		*)
+			_try_existing binary || _try_existing source
+			return $?
+			;;
+	esac
 
 	if [[ -x "${existing_ver}/bin/go" &&  -s "${existing_env}" ]] ; then
 		# newer envs have existing semi-colon at end of line, because newer gimme
@@ -318,7 +330,7 @@ _try_binary() {
 _try_source() {
 	local src_tgz="${GIMME_TMP}/go${GIMME_GO_VERSION}.src.tar.gz"
 	local src_dir="${GIMME_VERSION_PREFIX}/go${GIMME_GO_VERSION}.src"
-	local src_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.${GIMME_OS}.${GIMME_ARCH}.env"
+	local src_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.src.env"
 
 	_source "${GIMME_GO_VERSION}" "${src_tgz}" || return 1
 	_extract "${src_tgz}" "${src_dir}" || return 1
@@ -502,8 +514,8 @@ GIMME_VERSION_PREFIX="$(_realpath "${GIMME_VERSION_PREFIX}")"
 GIMME_ENV_PREFIX="$(_realpath "${GIMME_ENV_PREFIX}")"
 
 if ! case "${GIMME_TYPE}" in
-	binary) _try_existing || _try_binary "${GIMME_GO_VERSION}" "${GIMME_ARCH}" ;;
-	source) _try_source || _try_git ;;
+	binary) _try_existing binary || _try_binary "${GIMME_GO_VERSION}" "${GIMME_ARCH}" ;;
+	source) _try_existing source || _try_source || _try_git ;;
 	git)    _try_git ;;
 	auto)   _try_existing || _try_binary  "${GIMME_GO_VERSION}" "${GIMME_ARCH}" || _try_source || _try_git ;;
 	*)


### PR DESCRIPTION
Previously, gimme did not look for a pre-existing installation of the
requested version if `GIMME_TYPE` was set to "source". This commit
places the environment file for a source version at a different
location from the corresponding binary version so that we can detect if
we already have a valid source installation.

Fixes https://github.com/travis-ci/gimme/issues/43
