### PR TITLE
Add support for MinGW

### DIFF
--- a/gimme
+++ b/gimme
@@ -109,6 +109,11 @@ _binary() {
 			"${urls[@]}"
 		)
 	fi
+	if [ "${GIMME_OS}" = 'windows' ] ; then
+		urls=(
+			"https://storage.googleapis.com/golang/go${version}.${GIMME_OS}-${arch}.zip"
+		)
+	fi
 	_do_curls "${file}" "${urls[@]}"
 }
 
@@ -153,7 +158,14 @@ _checkout() {
 # _extract "file.tar.gz" "dir"
 _extract() {
 	mkdir -p "${2}"
-	tar -xf "${1}" -C "${2}" --strip-components 1
+
+	if [[ "${1}" == *.tar.gz ]] ; then
+		tar -xf "${1}" -C "${2}" --strip-components 1
+	else
+		unzip -q "${1}" -d "${2}"
+		mv "${2}"/go/* "${2}"
+		rmdir "${2}"/go
+	fi
 }
 
 # _setup_bootstrap
@@ -290,6 +302,10 @@ _try_binary() {
 	local bin_dir="${GIMME_VERSION_PREFIX}/go${version}.${GIMME_OS}.${arch}"
 	local bin_env="${GIMME_ENV_PREFIX}/go${version}.${GIMME_OS}.${arch}.env"
 
+	if [ "${GIMME_OS}" = 'windows' ] ; then
+		bin_tgz=${bin_tgz%.tar.gz}.zip
+	fi
+
 	_binary "${version}" "${bin_tgz}" "${arch}" || return 1
 	_extract "${bin_tgz}" "${bin_dir}" || return 1
 	_env "${bin_dir}" | tee "${bin_env}" || return 1
@@ -370,6 +386,17 @@ _assert_version_given() {
 : ${GIMME_GO_GIT_REMOTE:=https://github.com/golang/go.git}
 : ${GIMME_TYPE:=auto} # 'auto', 'binary', 'source', or 'git'
 : ${GIMME_BINARY_OSX:=osx10.8}
+
+if [[ "${GIMME_OS}" == mingw* ]] ; then
+	# Minimalist GNU for Windows
+	GIMME_OS='windows'
+
+	if [ "${GIMME_ARCH}" = 'i686' ] ; then
+		GIMME_ARCH="386"
+	else
+		GIMME_ARCH="amd64"
+	fi
+fi
 
 while [[ $# -gt 0 ]]; do
 	case "${1}" in

--- a/gimme
+++ b/gimme
@@ -40,6 +40,7 @@
 #
 set -e
 shopt -s nullglob
+shopt -s dotglob
 set -o pipefail
 
 [[ ${GIMME_DEBUG} ]] && set -x


### PR DESCRIPTION
This pull request adds support for MinGW, a minimalist GNU that ships with the [Windows git client](https://git-scm.com/downloads). The main advantage here is that a beginner dev can click through the Windows installer, select "Git Bash Here" from the right-click menu, and use Gimme:

``` bash
# MyUser@Win7 MINGW32 /e/gimme (master)
$ eval "$(GIMME_GO_VERSION=1.7 ./gimme)"

# MyUser@Win7 MINGW32 /e/gimme (master)
$ go version
go version go1.7 windows/386
```

This is currently the minimal change to get binary support working, and could be a bit cleaner (variables are still called bin_tgz, etc). It might also be nice to support Windows 10 Anniversary Edition's bash, but I don't have such a platform available to test.

Hopefully, this is good enough to merge with a tweak or two, since out of the gate every user of the default Windows Git client can get access to a happy Go installer :smile:
