### PR TITLE
Use 1.7 for bootstraping

### DIFF
--- a/gimme
+++ b/gimme
@@ -169,7 +169,7 @@ _extract() {
 
 # _setup_bootstrap
 _setup_bootstrap() {
-	local versions=("1.6" "1.5" "1.4")
+	local versions=("1.7" "1.6" "1.5" "1.4")
 
 	# try existing
 	for v in "${versions[@]}" ; do


### PR DESCRIPTION
This fixes `gimme tip` on Sierra.