### PR TITLE
Add native arm64 builds

### DIFF
--- a/gimme
+++ b/gimme
@@ -490,10 +490,17 @@ _versint() {
 	printf '1%03d%03d%03d%03d' "${args[@]}"
 }
 
+_to_goarch() {
+	case "${1}" in
+		aarch64) echo "arm64" ;;
+		*) echo "${1}" ;;
+	esac
+}
+
 : "${GIMME_OS:=$(uname -s | tr '[:upper:]' '[:lower:]')}"
 : "${GIMME_HOSTOS:=$(uname -s | tr '[:upper:]' '[:lower:]')}"
-: "${GIMME_ARCH:=$(uname -m)}"
-: "${GIMME_HOSTARCH:=$(uname -m)}"
+: "${GIMME_ARCH:=$(_to_goarch "$(uname -m)")}"
+: "${GIMME_HOSTARCH:=$(_to_goarch "$(uname -m)")}"
 : "${GIMME_ENV_PREFIX:=${HOME}/.gimme/envs}"
 : "${GIMME_VERSION_PREFIX:=${HOME}/.gimme/versions}"
 : "${GIMME_TMP:=${TMPDIR:-/tmp}/gimme}"


### PR DESCRIPTION
Add support to allow gimme to run on arm64 machines.  

arm64 support was added in go1.5, but go1.5 needs a bootstrap compiler to build.  As of now, there are no official arm64 golang binaries to use as a bootstrap compiler, so the patch `gimme: Add url for arm64 bootstrap binary` adds a work-around.

See https://github.com/golang/go/issues/19082 (proposal: build: distribute linux/arm64 binaries for Go releases).