### PR TITLE
Add 1.8, 1.9 as bootstrap candidates

### DIFF
--- a/gimme
+++ b/gimme
@@ -175,7 +175,7 @@ _extract() {
 
 # _setup_bootstrap
 _setup_bootstrap() {
-	local versions=("1.7" "1.6" "1.5" "1.4")
+	local versions=("1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
 
 	# try existing
 	for v in "${versions[@]}"; do


### PR DESCRIPTION
ARM64 machines will need to bootstrap with go1.9 or greater.

Sorry I forgot this in https://github.com/travis-ci/gimme/pull/95 (Add native arm64 builds).