### PR TITLE
Add -k/--known to list known Go versions

### DIFF
--- a/gimme
+++ b/gimme
@@ -411,7 +411,7 @@ _list_known() {
 	done <"${list}"
 
 	rm -f "${list}" &>/dev/null
-	echo -e "${known}" |sort -n -r |uniq
+	echo -e "${known}" | sort -n -r | uniq
 }
 
 _realpath() {

--- a/gimme
+++ b/gimme
@@ -411,7 +411,7 @@ _list_known() {
 	done <"${list}"
 
 	rm -f "${list}" &>/dev/null
-	echo -e "${known}" | sort -n -r | uniq
+	echo -e "${known}" | grep . | sort -n -r | uniq
 }
 
 _realpath() {

--- a/gimme
+++ b/gimme
@@ -395,6 +395,23 @@ _list_versions() {
 	done
 }
 
+_list_known() {
+	local exp="go([[:alnum:]\.]*)\.src.*" # :alnum: catches beta versions too
+	local list="${GIMME_TMP}/known-versions"
+	local known=""
+
+	_do_curl "${GIMME_LIST_KNOWN}" "${list}"
+
+	while read -r line; do
+		if [[ "${line}" =~ ${exp} ]]; then
+			known="$known\n${BASH_REMATCH[1]}"
+		fi
+	done <"${list}"
+
+	rm -f "${list}" &>/dev/null
+	echo -e "${known}" |sort -n -r |uniq
+}
+
 _realpath() {
 	# shellcheck disable=SC2005
 	[ -d "$1" ] && echo "$(cd "$1" && pwd)" || echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
@@ -510,6 +527,7 @@ _to_goarch() {
 : "${GIMME_TYPE:=auto}" # 'auto', 'binary', 'source', or 'git'
 : "${GIMME_BINARY_OSX:=osx10.8}"
 : "${GIMME_DOWNLOAD_BASE:=https://storage.googleapis.com/golang}"
+: "${GIMME_LIST_KNOWN:=https://golang.org/dl}"
 
 # The version prefix must be an absolute path
 case "${GIMME_VERSION_PREFIX}" in
@@ -553,6 +571,10 @@ while [[ $# -gt 0 ]]; do
 			;;
 		-l | --list | list)
 			_list_versions
+			exit 0
+			;;
+		-k | --known | known)
+			_list_known
 			exit 0
 			;;
 		-f | --force | force)

--- a/gimme
+++ b/gimme
@@ -17,6 +17,7 @@
 #+    -V --version version - show the version only and exit
 #+        -f --force force - remove the existing go installation if present prior to install
 #+          -l --list list - list installed go versions and exit
+#+        -k --known known - list known go versions and exit
 #+  -
 #+  Influential env vars:
 #+  -
@@ -37,6 +38,7 @@
 #+       GIMME_CGO_ENABLED - enable build of cgo support
 #+     GIMME_CC_FOR_TARGET - cross compiler for cgo support
 #+     GIMME_DOWNLOAD_BASE - override base URL dir for download (default '${GIMME_DOWNLOAD_BASE}')
+#+        GIMME_LIST_KNOWN - override base URL for known go versions (default '${GIMME_LIST_KNOWN}')
 #+  -
 #
 set -e

--- a/gimme
+++ b/gimme
@@ -400,7 +400,9 @@ _list_versions() {
 _list_known() {
 	local exp="go([[:alnum:]\.]*)\.src.*" # :alnum: catches beta versions too
 	local list="${GIMME_TMP}/known-versions"
-	local known=""
+
+	local known
+	known="$(_list_versions 2>/dev/null)"
 
 	_do_curl "${GIMME_LIST_KNOWN}" "${list}"
 


### PR DESCRIPTION
I found myself visiting the Go release notes page to see which patch releases were available for specific releases. This PR makes that list available with `gimme -k`.

I used `https://golang.org/dl` as the base list URL instead of `GIMME_DOWNLOAD_BASE` because the latter list doesn't include the (current) 1.9 beta. The `golang.org` list doesn't include old betas or release candidates, so maybe a combination of the two would be a better approach?