### PR TITLE
Let's call it master everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ gimme stable
 Or to install and use the development version (master branch) of Go:
 
 ``` bash
-gimme tip
+gimme master
 ```
 
 To list installed versions of Go:


### PR DESCRIPTION
It's already `master` in Travis CI docs: https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use