### PR TITLE
Version number robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,6 @@ update-binary-versions: force-update-versions $(KNOWN_BINARY_VERSIONS_FILES)
 .testdata/sample-binary-%: .testdata/binary-%
 	$(RM) $@
 	$(CAT) .testdata/stubheader-sample > $@
-	for prefix in $$($(SED_STRIP_COMMENTS) $< | $(GREP) -E '\.[0-9][0-9]*(\.|$$)' | $(CUT) -b1-3 | $(SORT) -r | $(UNIQ)) ; do \
+	for prefix in $$($(SED_STRIP_COMMENTS) $< | $(GREP) -E '\.[0-9]+(\.|$$)' | $(CUT) -b1-3 | $(SORT) -r | $(UNIQ)) ; do \
 		$(GREP) "^$${prefix}" $< | $(GREP) -vE 'rc|beta' | $(SORT) -r | $(HEAD) -1 >> $@ ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,6 @@ update-binary-versions: force-update-versions $(KNOWN_BINARY_VERSIONS_FILES)
 .testdata/sample-binary-%: .testdata/binary-%
 	$(RM) $@
 	$(CAT) .testdata/stubheader-sample > $@
-	for prefix in $$($(SED_STRIP_COMMENTS) $< | $(GREP) -E '\.[0-9]\.|\.9' | $(CUT) -b1-3 | $(SORT) -r | $(UNIQ)) ; do \
+	for prefix in $$($(SED_STRIP_COMMENTS) $< | $(GREP) -E '\.[0-9][0-9]*(\.|$$)' | $(CUT) -b1-3 | $(SORT) -r | $(UNIQ)) ; do \
 		$(GREP) "^$${prefix}" $< | $(GREP) -vE 'rc|beta' | $(SORT) -r | $(HEAD) -1 >> $@ ; \
 	done


### PR DESCRIPTION
Version 1.10 is likely to come.  The current regex recently changed from
`<something>.<single-digit>.<something>` to that _or_ `<something>.9`

Instead allow:
  `<something>.<one-or-more-digits>(either .<something> or END)`

@meatballhat 