### PR TITLE
Paginate bucket in 'gimme stable'

### DIFF
--- a/gimme
+++ b/gimme
@@ -439,20 +439,20 @@ _get_curr_stable() {
 
 _update_stable() {
 	local stable="${1}"
-	local exp="go([[:digit:]\.]*)\.src.*"
 	local tmp_versions="${GIMME_TMP}/versions"
-	local url="https://www.googleapis.com/storage/v1/b/golang/o?fields=items%2Fname&maxResults=999999"
+	local url="https://www.googleapis.com/storage/v1/b/golang/o?fields=items%2Fname,nextPageToken"
 	local vers=""
+	local nextPageToken
 
 	mkdir -p "$(dirname "${stable}")"
 
 	_do_curl "${url}" "${tmp_versions}"
+	vers="$(jq -r '.items[].name | capture("go(?<ver>[[:digit:]\\.]*)\\.src.*").ver' <"$tmp_versions")"
 
-	while read -r line; do
-		if [[ "${line}" =~ ${exp} ]]; then
-			vers="$vers\n${BASH_REMATCH[1]}"
-		fi
-	done <"${tmp_versions}"
+	while nextPageToken=$(jq --exit-status --raw-output '.nextPageToken' <"$tmp_versions"); do
+		_do_curl "${url}&pageToken=${nextPageToken}" "${tmp_versions}"
+		vers="${vers}\n$(jq -r '.items[].name | capture("go(?<ver>[[:digit:]\\.]*)\\.src.*").ver' <"$tmp_versions")"
+	done
 
 	rm -f "${tmp_versions}" &>/dev/null
 	echo -e "${vers}" | sort -n -r | head -n1 >"${stable}"


### PR DESCRIPTION
This is a similar change to
https://github.com/travis-ci/gimme/pull/108/commits but in bash, rather
than python.

It's possible we should use only one implementation, not two, but this
seems like the simpler fix, especially since I'm not sure if depending
on python is appropriate for this script.

This fixes #111

Note, the 'maxResults' value is ignored if it's over 1000, per google
storage docs, so dropping it should have no behavioral change.