### PR TITLE
Updates to how copyright and contributors are tracked

### DIFF
--- a/.testdata/sample-binary-darwin
+++ b/.testdata/sample-binary-darwin
@@ -7,7 +7,6 @@
 # Instead we include:
 #  * all versions of the current release series
 #  * the last formal release in all previous series
-#  * at least one beta and rc
 
 #
 1.9.2

--- a/.testdata/sample-binary-linux
+++ b/.testdata/sample-binary-linux
@@ -7,7 +7,6 @@
 # Instead we include:
 #  * all versions of the current release series
 #  * the last formal release in all previous series
-#  * at least one beta and rc
 
 #
 1.9.2

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,27 @@
+gimme was built by these wonderful humans:
+- Alexey Palazhchenko
+- Andrew Stone
+- Asato Wakisaka
+- Ben Burkert
+- Carmen Andoh
+- Dan Buch
+- Daniel Martí
+- Dan Peterson
+- Dylan Waits
+- Euan Kemp
+- Florin Patan
+- Francisco Souza
+- Frederick F. Kautz IV
+- Gemma Lynn
+- Geoff Levand
+- Hiro Asari
+- Koichi Shiraishi
+- lupan2005
+- Mike Danese
+- Nathaniel Kofalt
+- Nathan Youngman
+- Otto Jongerius
+- Phil Pennock
+- Thomas Heller
+- Tianon Gravi
+- Tom Cahill

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Dan Buch, Tianon Gravi, Travis CI GmbH
+Copyright (c) 2015-2018 gimme contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gimme
+++ b/gimme
@@ -50,7 +50,7 @@ set -o pipefail
 [[ ${GIMME_DEBUG} ]] && set -x
 
 GIMME_VERSION="v1.3.0"
-GIMME_COPYRIGHT="Copyright (c) 2015-2018 Dan Buch, Tianon Gravi, Travis CI GmbH"
+GIMME_COPYRIGHT="Copyright (c) 2015-2018 gimme contributors"
 GIMME_LICENSE_URL="https://raw.githubusercontent.com/travis-ci/gimme/v1.3.0/LICENSE"
 export GIMME_VERSION
 export GIMME_COPYRIGHT


### PR DESCRIPTION
asserting matching copyrights instead of munging `gimme` in place,
generating a list of contributors from git, and updating the copyright
to better reflect community authorship.