### PR TITLE
Simplify check for current stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Install go, yay!
 
 ## Installation & usage
 
-Requires `jq` for JSON processing.  This is a common tool.
-
 Install from github:
 
 ``` bash
@@ -20,7 +18,7 @@ chmod +x ~/bin/gimme
 [Homebrew](http://brew.sh) (OS X):
 
 ```bash
-brew install jq gimme
+brew install gimme
 ```
 
 [Arch AUR](https://aur.archlinux.org/) (Arch Linux), substituting `yaourt` with

--- a/gimme
+++ b/gimme
@@ -474,24 +474,9 @@ _get_curr_stable() {
 
 _update_stable() {
 	local stable="${1}"
-	local tmp_versions="${GIMME_TMP}/versions"
-	local url="https://www.googleapis.com/storage/v1/b/golang/o?fields=items%2Fname,nextPageToken"
-	local vers=""
-	local nextPageToken
+	local url="https://golang.org/VERSION?m=text"
 
-	mkdir -p "$(dirname "${stable}")"
-
-	_do_curl "${url}" "${tmp_versions}"
-	vers="$(jq -r '.items[].name | capture("go(?<ver>[[:digit:]\\.]*)\\.src.*").ver' <"$tmp_versions")"
-
-	while nextPageToken=$(jq --exit-status --raw-output '.nextPageToken' <"$tmp_versions"); do
-		_do_curl "${url}&pageToken=${nextPageToken}" "${tmp_versions}"
-		# shellcheck disable=SC1117
-		vers="${vers}\n$(jq -r '.items[].name | capture("go(?<ver>[[:digit:]\\.]*)\\.src.*").ver' <"$tmp_versions")"
-	done
-
-	rm -f "${tmp_versions}" &>/dev/null
-	echo -e "${vers}" | sort -n -r | head -n1 >"${stable}"
+	_do_curl "${url}" "${stable}"
 }
 
 _stat_unix() {


### PR DESCRIPTION
golang.org exposes an API just for this, which should always be up to date.

The current implementation is convoluted and error-prone (I am currently seeing it return Go 1.7.6 as stable), so this should be an improvement.