### PR TITLE
Trim 'go' prefix from stable version read from golang.org api

### DIFF
--- a/gimme
+++ b/gimme
@@ -477,6 +477,7 @@ _update_stable() {
 	local url="https://golang.org/VERSION?m=text"
 
 	_do_curl "${url}" "${stable}"
+	sed -i '' -e 's/^go\(.*\)/\1/' "${stable}"
 }
 
 _stat_unix() {


### PR DESCRIPTION
The version returned by the golang.org/VERSION api includes a `go` prefix. So 1.9.3 is actually `go1.9.3`. This caused gimme to start building Go from source with the tag `go1.9.3` instead of simply downloading it.

This PR ensures we trim the `go` prefix in the returned version.