### PR TITLE
Fix inplace sed for compatibility with both GNU sed and BSD sed

### DIFF
--- a/gimme
+++ b/gimme
@@ -477,7 +477,7 @@ _update_stable() {
 	local url="https://golang.org/VERSION?m=text"
 
 	_do_curl "${url}" "${stable}"
-	sed -i '' -e 's/^go\(.*\)/\1/' "${stable}"
+	sed -i.old -e 's/^go\(.*\)/\1/' "${stable}"
 }
 
 _stat_unix() {


### PR DESCRIPTION
The sed command to remove the `go` prefix from the stable version file was
incorrect using GNU sed and caused the script to print the error message:

```
sed: can't read : No such file or directory
```

The replace would work as intended, however this error message can make users
think there's something wrong with `gimme`.

This happens because for gnused the `-i` argument must either have a suffix
argument without any whitespace separating it from the flag or be ommited.
However, simply having `-i` without any argument would break this command on
bsdsed.

This PR adds a `.old` suffix to the `-i` argument making it compatible with both
gnused and bsdsed.

This problem was introduced by my previous PR #123 and I'm sorry for not
noticing this.

It's a sed world. :)