### PR TITLE
Implement parsing of git revisions specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ To make this easier, and reduce duplicate invocations, Gimme now supports a
 of a version specifier.  This is the `--resolve` option.  It handles the `.x`
 suffix and the `stable` string; all other inputs are passed through unchanged,
 although unknown names will be accompanied by an error message and an exit
-code of 2.
+code of 2.  A valid version identifier, even if not currently downloadable
+from upstream, will resolve successfully.  "Can resolve" is not "exists".
 
 Thus given a list of versions to invoke against, tooling might do a first pass
 to use `--resolve` on each and de-duplicate, so that if an alias and a

--- a/gimme
+++ b/gimme
@@ -241,7 +241,7 @@ _checkout() {
 		[[ "${spec}" != "@" ]] || spec="HEAD"
 	fi
 
-	try_spec() { git -C "${godir}" reset -q --hard "$@"; }
+	try_spec() { git -C "${godir}" reset -q --hard "$@" -- 2>/dev/null; }
 
 	retval=1
 	if ((probe_named)); then

--- a/gimme
+++ b/gimme
@@ -470,7 +470,7 @@ _try_source() {
 	local src_dir="${GIMME_VERSION_PREFIX}/go${GIMME_GO_VERSION}.src"
 	local src_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.src.env"
 
-	[[ "${version}" =~ ${ALLOWED_UPSTREAM_VERSION_RE} ]] || return 1
+	[[ "${GIMME_GO_VERSION}" =~ ${ALLOWED_UPSTREAM_VERSION_RE} ]] || return 1
 
 	_source "${GIMME_GO_VERSION}" "${src_tgz}" || return 1
 	_extract "${src_tgz}" "${src_dir}" || return 1

--- a/gimme
+++ b/gimme
@@ -69,6 +69,21 @@ die() {
 	exit 1
 }
 
+# We don't want to go around hitting Google's servers with requests for
+# files named HEAD@{date}.tar so we only try binary/source downloads if
+# it looks like a plausible name to us.
+# We don't need to support 0. releases of Go.
+# We don't support 5 digit major-versions of Go (limit back-tracking in RE).
+# We don't support very long versions
+#   (both to avoid annoying download server operators with attacks and
+#    because regexp backtracking can be pathological).
+# Per _assert_version_given we do assume 2.0 not 2
+ALLOWED_UPSTREAM_VERSION_RE='^[1-9][0-9]{0,3}(\.[0-9][0-9a-zA-Z_-]{,9})+$'
+#
+# The main path which allowed these to leak upstream before has been closed
+# but a valid git repo tag or branch-name will still reach the point of
+# being _tried_ upstream.
+
 # _do_curl "url" "file"
 _do_curl() {
 	mkdir -p "$(dirname "${2}")"
@@ -199,15 +214,60 @@ _fetch() {
 }
 
 # _checkout "version" "dir"
+# NB: might emit a "renamed version" on stdout
 _checkout() {
-	_fetch "${2}"
-	(cd "${2}" && {
-		git reset -q --hard "origin/${1}" ||
-			git reset -q --hard "origin/go${1}" ||
-			{ [ "${1}" = 'tip' ] && git reset -q --hard origin/master; } ||
-			git reset -q --hard "refs/tags/${1}" ||
-			git reset -q --hard "refs/tags/go${1}"
-	} 2>/dev/null)
+	local spec="${1:?}" godir="${2:?}"
+	# We are called twice, once during validation that a version was given and
+	# later during build.  We don't want to fetch twice, so we are fetching
+	# during the validation only, in the caller.
+
+	if [[ "${spec}" =~ ^[0-9a-f]{6,}$ ]]; then
+		# We always treat this as a commit sha, whether instead of doing
+		# branch tests etc.  It looks like a commit sha and the Go maintainers
+		# aren't daft enough to use pure hex for a tag or branch.
+		git -C "$godir" reset -q --hard "${spec}" || return 1
+		return 0
+	fi
+
+	# If spec looks like HEAD^{something} or HEAD^^^ then trying
+	# origin/$spec would succeed but we'd write junk to the filesystem,
+	# propagating annoying characters out.
+	local retval probe_named disallow rev
+
+	probe_named=1
+	disallow='[@^~:{}]'
+	if [[ "${spec}" =~ $disallow ]]; then
+		probe_named=0
+		[[ "${spec}" != "@" ]] || spec="HEAD"
+	fi
+
+	try_spec() { git -C "${godir}" reset -q --hard "$@"; }
+
+	retval=1
+	if ((probe_named)); then
+		retval=0
+		try_spec "origin/${spec}" ||
+			try_spec "origin/go${spec}" ||
+			{ [[ "${spec}" == "tip" ]] && try_spec origin/master; } ||
+			try_spec "refs/tags/${spec}" ||
+			try_spec "refs/tags/go${spec}" ||
+			retval=1
+	fi
+
+	if ((retval)); then
+		retval=0
+		# We're about to reset anyway, if we succeed, so we should reset to a
+		# known state before parsing what might be relative specs
+		try_spec origin/master &&
+			rev="$(git -C "${godir}" rev-parse --verify -q "${spec}^{object}")" &&
+			try_spec "${rev}" &&
+			git -C "${godir}" rev-parse --verify -q --short=12 "${rev}" ||
+			retval=1
+		# that rev-parse prints to stdout, so we can affect the version seen
+	fi
+
+	unset -f try_spec
+	return $retval
 }
 
 # _extract "file.tar.gz" "dir"
@@ -339,7 +399,8 @@ _env_alias() {
 	fi
 
 	if [[ "$(GOROOT="${1}" "${1}/bin/go" env GOHOSTOS)" == "${GIMME_OS}" && "$(GOROOT="${1}" "${1}/bin/go" env GOHOSTARCH)" == "${GIMME_ARCH}" ]]; then
-		local dest="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.env"
+		# GIMME_GO_VERSION might be a branch, which can contain '/'
+		local dest="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION//\//__}.env"
 		cp "${2}" "${dest}"
 		ln -sf "${dest}" "${GIMME_ENV_PREFIX}/latest.env"
 		echo "${dest}"
@@ -392,6 +453,8 @@ _try_binary() {
 	local bin_dir="${GIMME_VERSION_PREFIX}/go${version}.${GIMME_OS}.${arch}"
 	local bin_env="${GIMME_ENV_PREFIX}/go${version}.${GIMME_OS}.${arch}.env"
 
+	[[ "${version}" =~ ${ALLOWED_UPSTREAM_VERSION_RE} ]] || return 1
+
 	if [ "${GIMME_OS}" = 'windows' ]; then
 		bin_tgz=${bin_tgz%.tar.gz}.zip
 	fi
@@ -407,6 +470,8 @@ _try_source() {
 	local src_dir="${GIMME_VERSION_PREFIX}/go${GIMME_GO_VERSION}.src"
 	local src_env="${GIMME_ENV_PREFIX}/go${GIMME_GO_VERSION}.src.env"
 
+	[[ "${version}" =~ ${ALLOWED_UPSTREAM_VERSION_RE} ]] || return 1
+
 	_source "${GIMME_GO_VERSION}" "${src_tgz}" || return 1
 	_extract "${src_tgz}" "${src_dir}" || return 1
 	_compile "${src_dir}" || return 1
@@ -415,11 +480,23 @@ _try_source() {
 	echo "export GIMME_ENV=\"$(_env_alias "${src_dir}" "${src_env}")\""
 }
 
+# We do _not_ try to use any version caching with _try_existing(), but instead
+# build afresh each time.  We don't want to deal with someone moving the repo
+# to other-version, doing an install, then resetting it back to
+# last-version-we-saw and thus introducing conflicts.
+#
+# If you want to re-use a built-at-spec version, then avoid moving the repo
+# and source the generated .env manually.
+# Note that the env will just refer to the 'go' directory, so it's not safe
+# to reuse anyway.
 _try_git() {
 	local git_dir="${GIMME_VERSION_PREFIX}/go"
 	local git_env="${GIMME_ENV_PREFIX}/go.git.${GIMME_OS}.${GIMME_ARCH}.env"
+	local resolved_sha
 
-	_checkout "${GIMME_GO_VERSION}" "${git_dir}" || return 1
+	# Any tags should have been resolved when we asserted that we were
+	# given a version, so no need to handle that here.
+	_checkout "${GIMME_GO_VERSION}" "${git_dir}" >/dev/null || return 1
 	_compile "${git_dir}" || return 1
 	_try_install_race "${git_dir}" || return 1
 	_env "${git_dir}" | tee "${git_env}" || return 1
@@ -615,6 +692,7 @@ _assert_version_given() {
 	# Note: _resolve_version calls back to us (_assert_version_given), but
 	# only for cases where the version does not end with .x, so this should
 	# be safe.
+	# This should be untangled.  PRs accepted, good starter project.
 	if [[ "${GIMME_GO_VERSION}" == *.x ]]; then
 		GIMME_GO_VERSION="$(_resolve_version "${GIMME_GO_VERSION}")" || ${ASSERT_ABORT:-exit} 1
 	fi
@@ -623,9 +701,22 @@ _assert_version_given() {
 		return 0
 	fi
 
+	# Here we resolve symbolic references.  If we don't, then we get some
+	# random git tag name being accepted as valid and then we try to
+	# curl garbage from upstream.
 	if [[ "${GIMME_TYPE}" == "auto" || "${GIMME_TYPE}" == "git" ]]; then
 		local git_dir="${GIMME_VERSION_PREFIX}/go"
-		_checkout "${GIMME_GO_VERSION}" "${git_dir}" && return 0
+		local resolved_sha
+		_fetch "${git_dir}"
+		if resolved_sha="$(_checkout "${GIMME_GO_VERSION}" "${git_dir}")"; then
+			if [[ -n "${resolved_sha}" ]]; then
+				# Break our normal silence, this one really needs to be seen on stderr
+				# always; auditability and knowing what version of Go you got wins.
+				warn "resolved '${GIMME_GO_VERSION}' to '${resolved_sha}'"
+				GIMME_GO_VERSION="${resolved_sha}"
+			fi
+			return 0
+		fi
 	fi
 
 	echo >&2 'error: GIMME_GO_VERSION not recognized as valid'
@@ -716,6 +807,9 @@ while [[ $# -gt 0 ]]; do
 		exit 0
 		;;
 	-r | --resolve | resolve)
+		# The normal mkdir of versions is below; we don't want to move it up
+		# to where we create files just if asked our version; thus
+		# _resolve_version has to mkdir the versions dir itself.
 		if [[ $# -ge 2 ]]; then
 			_resolve_version "${2}"
 		elif [[ -n "${GIMME_GO_VERSION:-}" ]]; then

--- a/gimme
+++ b/gimme
@@ -78,7 +78,7 @@ die() {
 #   (both to avoid annoying download server operators with attacks and
 #    because regexp backtracking can be pathological).
 # Per _assert_version_given we do assume 2.0 not 2
-ALLOWED_UPSTREAM_VERSION_RE='^[1-9][0-9]{0,3}(\.[0-9][0-9a-zA-Z_-]{,9})+$'
+ALLOWED_UPSTREAM_VERSION_RE='^[1-9][0-9]{0,3}(\.[0-9][0-9a-zA-Z_-]{0,9})+$'
 #
 # The main path which allowed these to leak upstream before has been closed
 # but a valid git repo tag or branch-name will still reach the point of

--- a/runtests
+++ b/runtests
@@ -43,8 +43,6 @@ can_resolve_version() {
 sanity_checks() {
 	echo "---> doing sanity checks that all known versions resolve"
 	local v
-	GIMME_TYPE=binary
-	export GIMME_TYPE
 	for v in ${RUNTESTS_EXTRA_RESOLVE:-}; do
 		can_resolve_version "$v"
 	done

--- a/runtests
+++ b/runtests
@@ -10,10 +10,54 @@ main() {
 	local go_bootstrap_version="${1}"
 	shift
 
+	sanity_checks "$@"
+
 	echo "---> using bootstrap version ${go_bootstrap_version}"
 	eval "$(./gimme "${go_bootstrap_version}")"
 
 	"_test_${target}" "$@"
+}
+
+die() {
+	printf >&2 '***> %s\n' "$*"
+	exit 1
+}
+
+can_resolve_version() {
+	local GIMME_TYPE='binary'
+	export GIMME_TYPE
+	local want="${1}"
+	local ev r
+	ev=0
+	r="$(./gimme --resolve "${want}" 2>/dev/null)" || ev=$?
+	if ! [[ -n "${r}" ]]; then
+		die "no output resolving input version '${want}'"
+	fi
+	case $ev in
+	0) true ;;
+	2) die "failed to resolve version '${want}'" ;;
+	*) die "unexpected error resolving version '${want}'" ;;
+	esac
+}
+
+sanity_checks() {
+	echo "---> doing sanity checks that all known versions resolve"
+	local v
+	GIMME_TYPE=binary
+	export GIMME_TYPE
+	for v in ${RUNTESTS_EXTRA_RESOLVE:-}; do
+		can_resolve_version "$v"
+	done
+	for v in "$@"; do
+		case "${v}" in
+		master) continue ;;
+		go*) v="${v#go}" ;;
+		esac
+		can_resolve_version "${v}"
+		if [[ "${v}" =~ ^[0-9.]+$ ]]; then
+			can_resolve_version "${v}.x"
+		fi
+	done
 }
 
 _test_native() {


### PR DESCRIPTION
Implemented ability to work from git via specifiers; wondering if we
should switch to "must supply a `git:` prefix" for this, and perhaps for
branches/tags too?

We were double-pulling from git, and checking remote twice for URLs
which don't exist, and various other unpleasantness.  If the first pass
invocation via _assert_version_given said "yup, that git branch exists"
then for `GIMME_TYPE=auto` we'd try to fetch a tarball named for that
branch from the downloads page.

For the new stuff, we now canonicalize to a sane name for the version.
We also now use a regexp to restrict what we'll _try_ to pull from the
download mirrors, which helps both as belt+braces and because we don't
canonicalize tags/branches: I wanted to keep that behavior in case folks
depended upon it somehow.

We were also trusting the branch/tag to be sane to use in a filename in
`envs/` despite those both allowing `/` in them, so we now replace
forward-slashes in the filename to be written.

I've made `_checkout` avoid use of sub-shells and cleaned it up a fair
bit, I think it's easier to glance and see what's being tried now, even
if puzzling out the mechanism is "differently awkward", rather than
actively better.  (I think it's now easier to read for non-shell-expert
programmers with experience in most other languages.)

Added checks to runtests to make sure that all the things we expect to
resolve will resolve.

Resolves issue #49 