### PR TITLE
meta: Metadata fixes: sorting, bug-fixes etc

### DIFF
--- a/.testdata/sample-binary-darwin
+++ b/.testdata/sample-binary-darwin
@@ -9,6 +9,7 @@
 #  * the last formal release in all previous series
 
 #
+1.10
 1.9.4
 1.8.7
 1.7.6
@@ -17,4 +18,3 @@
 1.4.3
 1.3.3
 1.2.2
-1.10

--- a/.testdata/sample-binary-linux
+++ b/.testdata/sample-binary-linux
@@ -9,6 +9,7 @@
 #  * the last formal release in all previous series
 
 #
+1.10
 1.9.4
 1.8.7
 1.7.6
@@ -17,4 +18,3 @@
 1.4.3
 1.3.3
 1.2.2
-1.10

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ gimme was built by these wonderful humans:
 - Asato Wakisaka
 - Ben Burkert
 - Carmen Andoh
+- Cezar Sa Espinola
 - Dan Buch
 - Daniel Martí
 - Dan Peterson
@@ -15,8 +16,10 @@ gimme was built by these wonderful humans:
 - Gemma Lynn
 - Geoff Levand
 - Hiro Asari
+- Hiroshi Ioka
 - Koichi Shiraishi
 - lupan2005
+- Matt Larraz
 - Mike Danese
 - Nathaniel Kofalt
 - Nathan Youngman

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 SHELL := bash
 UNAME := $(shell uname)
 VERSION := $(shell git describe --always --tags)
+.DEFAULT_GOAL := all
+
+# Affects sorting for CONTRIBUTORS file; unfortunately these are not
+# totally names (standards opaque IIRC) but this should work for us.
+LC_COLLATE:=en_US.UTF-8
+# Alas, macOS collation is broken and generates spurious differences.
 
 AWK ?= awk
 CAT ?= cat
@@ -21,6 +27,13 @@ ifeq ($(UNAME), Darwin)
 	UNIQ := guniq
 endif
 
+ifeq "$(shell $(SORT) --version-sort </dev/null >/dev/null 2>&1 || echo no)" "no"
+	_ := $(warning "$(SORT) --version-sort not available, falling back to shell")
+	REV_VERSION_SORT := $(SED) -E 's/\.([0-9](\.|$$))/.00\1/g; s/\.([0-9][0-9](\.|$$))/.0\1/g' | $(SORT) --general-numeric-sort -r | $(SED) 's/\.00*/./g'
+else
+	REV_VERSION_SORT := $(SORT) --version-sort -r
+endif
+
 SED_STRIP_COMMENTS ?= $(SED) -n -e '/^[^\#]/p'
 
 KNOWN_BINARY_VERSIONS_FILES := \
@@ -35,7 +48,11 @@ all: lint CONTRIBUTORS assert-copyright $(KNOWN_BINARY_VERSIONS_FILES)
 .PHONY: clean
 clean:
 	$(RM) $(KNOWN_BINARY_VERSIONS_FILES) .testdata/object-urls
+ifeq ($(UNAME), Darwin)
+	$(warning Not deleting CONTRIBUTORS on macOS, locale sorting is broken)
+else
 	$(RM) CONTRIBUTORS
+endif
 
 .PHONY: lint
 lint:
@@ -46,7 +63,7 @@ lint:
 assert-copyright:
 	@$(DIFF) -u \
 		--label a/copyright/gimme \
-		<($(AWK) 'BEGIN { FS="="; } /^GIMME_COPYRIGHT/ { gsub(/"/, "", $$2); print $$2 }' gimme) \
+		<($(AWK) 'BEGIN { FS="="; } /^readonly GIMME_COPYRIGHT/ { gsub(/"/, "", $$2); print $$2 }' gimme) \
 		--label b/copyright/LICENSE \
 		<(awk '/^Copyright/ { print $$0 }' LICENSE)
 
@@ -76,10 +93,13 @@ update-binary-versions: force-update-versions $(KNOWN_BINARY_VERSIONS_FILES)
 .testdata/sample-binary-%: .testdata/binary-%
 	$(RM) $@
 	$(CAT) .testdata/stubheader-sample > $@
-	for prefix in $$($(SED_STRIP_COMMENTS) $< | $(GREP) -E '\.[0-9]+(\.|$$)' | $(CUT) -b1-3 | $(SORT) -r | $(UNIQ)) ; do \
-		$(GREP) "^$${prefix}" $< | $(GREP) -vE 'rc|beta' | $(SORT) -r | $(HEAD) -1 >> $@ ; \
+	for prefix in $$($(SED_STRIP_COMMENTS) $< | $(SED) -En 's/^([0-9]+\.[0-9]+)(\..*)?$$/\1/p' | $(REV_VERSION_SORT) | $(UNIQ)) ; do \
+		$(GREP) "^$${prefix}" $< | $(GREP) -vE 'rc|beta' | $(REV_VERSION_SORT) | $(HEAD) -1 >> $@ ; \
 	done
 
 CONTRIBUTORS:
+ifeq ($(UNAME), Darwin)
+	$(error macOS appears to have broken collation and will make spurious differences)
+endif
 	@echo 'gimme was built by these wonderful humans:' >$@
 	@$(GIT) log --format=%an | $(SORT) | $(UNIQ) | $(SED) 's/^/- /' >>$@

--- a/fetch-object-urls
+++ b/fetch-object-urls
@@ -3,6 +3,11 @@
 import json
 import sys
 
+if sys.version_info < (3,6):
+  raise Exception('Need at least Python 3.6 for this tool')
+  # https://docs.python.org/3/whatsnew/3.6.html
+  # > json.load() and json.loads() now support binary input.
+
 from urllib.request import urlopen
 from urllib.parse import quote as urlquote
 


### PR DESCRIPTION
1. The metadata version list was not sorted correctly, the usual `1.10`
   ordering issue; fix that with a version sort.
   * There are two implementations, I tested both on macOS via changing
     the `ifeq` guard to select (had a second `$(warning ...)` in for
     development to confirm branch selection).  The `sed` one is based
     on the code in the `gimme` script, but reversed and adjusted for
     `Makefile` syntax.
2. Using `$(CUT) -b1-3` is no longer correct for prefix selection, now
   that we have `1.10` as 4 digits.
3. My making `GIMME_COPYRIGHT` a `readonly` variable in fd746b1eb broke
   the `Makefile` rule for checking the two copyrights against each
   other; fix the `Makefile` to handle reality.
4. Committed the results of `make` fixing the sample files
5. I got a `CONTRIBUTORS` file with wildly different ordering; even
   after forcing on LC_COLLATE to a locally-valid name, there was no
   difference and $RandomGoogling suggest this is a known issue on
   macOS.  So disable CONTRIBUTORS mangling on macOS.
6. Trying to make metadata on Linux I hit an issue because
   `fetch-object-urls` requires Python 3.6; which is fair, because 3.6
   is an awesome release with many cool features which make it a
   compelling choice; but the script didn't guard against this and so
   bombed out later when trying to pass binary into the json module.
7. Updated CONTRIBUTORS on a Linux box

Yaks shaved: 3.