### PR TITLE
Handle 1.x as a pattern correctly

### DIFF
--- a/gimme
+++ b/gimme
@@ -611,16 +611,16 @@ _resolve_version() {
 	local base="${1%.x}"
 	local ver last='' known
 	known="$(_update_remote_known_list_if_needed)" # will be version-sorted
+	if [[ ! "${base}" =~ ^[0-9.]+$ ]]; then
+		warn "resolve pattern '${base}.x' invalid for .x finding"
+		return 2
+	fi
+	local search="^${base//./\\.}\\.[0-9.]+\$"
+	warn "search: '${search}'"
 	# avoid regexp attacks
 	while read -r ver; do
-		case "${ver}" in
-		${base})
-			last="${ver}"
-			;;
-		${base}.*)
-			last="${ver}"
-			;;
-		esac
+		[[ "${ver}" =~ $search ]] || continue
+		last="${ver}"
 	done <"$known"
 	if [[ -n "${last}" ]]; then
 		echo "${last}"

--- a/gimme
+++ b/gimme
@@ -615,8 +615,8 @@ _resolve_version() {
 		warn "resolve pattern '${base}.x' invalid for .x finding"
 		return 2
 	fi
-	local search="^${base//./\\.}\\.[0-9.]+\$"
-	warn "search: '${search}'"
+	# The `.x` is optional; "1.10" matches "1.10.x"
+	local search="^${base//./\\.}(\\.[0-9.]+)?\$"
 	# avoid regexp attacks
 	while read -r ver; do
 		[[ "${ver}" =~ $search ]] || continue

--- a/runtests
+++ b/runtests
@@ -27,6 +27,7 @@ can_resolve_version() {
 	local GIMME_TYPE='binary'
 	export GIMME_TYPE
 	local want="${1}"
+	local verbose="${2:-false}"
 	local ev r
 	ev=0
 	r="$(./gimme --resolve "${want}" 2>/dev/null)" || ev=$?
@@ -38,22 +39,26 @@ can_resolve_version() {
 	2) die "failed to resolve version '${want}'" ;;
 	*) die "unexpected error resolving version '${want}'" ;;
 	esac
+	if $verbose; then
+		printf '%s\n' "${r}"
+	fi
 }
 
 sanity_checks() {
 	echo "---> doing sanity checks that all known versions resolve"
-	local v
+	local v got
 	for v in ${RUNTESTS_EXTRA_RESOLVE:-}; do
 		can_resolve_version "$v"
 	done
-	for v in "$@"; do
+	for v in "$@" 1; do
 		case "${v}" in
 		master) continue ;;
 		go*) v="${v#go}" ;;
 		esac
-		can_resolve_version "${v}"
+		[[ $v == 1 ]] || can_resolve_version "${v}"
 		if [[ "${v}" =~ ^[0-9.]+$ ]]; then
-			can_resolve_version "${v}.x"
+			got="$(can_resolve_version "${v}.x" true)"
+			[[ "$got" =~ ^[0-9.]+$ ]] || die "resolved '${v}.x' to non-stable '${got}'"
 		fi
 	done
 }


### PR DESCRIPTION
The previous logic worked for `1.NN.x` but not for `1.x`.  I had avoided use of regular expressions based on input, as an attack vector.

Validate the input to be sane, then use it to construct a regex after all, and search for proper releases.

Improve tests around .x handling to check for `1.x` and to confirm not just that things resolve but that they resolve according to our documented assertion that we only issue a stable version number.

Fixes #152 