### PR TITLE
Unset GO111MODULE within Gimme itself

### DIFF
--- a/gimme
+++ b/gimme
@@ -890,6 +890,8 @@ unset GOPATH
 unset GOROOT
 unset CGO_ENABLED
 unset CC_FOR_TARGET
+# GO111MODULE breaks build of Go itself
+unset GO111MODULE
 
 mkdir -p "${GIMME_VERSION_PREFIX}" "${GIMME_ENV_PREFIX}"
 # The envs dir stays small and provides a record of what had been installed


### PR DESCRIPTION
Presumably when `GO111MODULE` is set in environ when calling `gimme`, it's part of generic setup to be used by the Go toolchain when building the code being CI tested and the intent is not to try to tell Go, when building from source, that it should be requiring the new Go 1.11 module semantics.

Forcibly unset `GO111MODULE` in Gimme itself, but do not do anything to add this to the emitted environment variables.

Without this, `gimme master` currently fails; with this change, it succeeds.

Fixes #158 