### PR TITLE
If GIMME_DEBUG >= 2 then `make.bash -v`

### DIFF
--- a/gimme
+++ b/gimme
@@ -327,8 +327,8 @@ _compile() {
 		export CC_FOR_TARGET="${GIMME_CC_FOR_TARGET}"
 
 		local make_log="${1}/make.${GOOS}.${GOARCH}.log"
-		if [[ "${GIMME_DEBUG}" -gt "1" ]]; then
-			./make.bash 2>&1 | tee "${make_log}" 1>&2 || return 1
+		if [[ "${GIMME_DEBUG}" -ge "2" ]]; then
+			./make.bash -v 2>&1 | tee "${make_log}" 1>&2 || return 1
 		else
 			./make.bash &>"${make_log}" || return 1
 		fi


### PR DESCRIPTION
We already have logic to handle `GIMME_DEBUG` looking like a number and capturing more output here; just use one number higher to ask `make.bash` to be verbose.

Slightly repetitive, but cleaner and easier to understand than conditional arrays or stuff which would affect shellcheck if we relied upon empty unquoted args being dropped.

With this and without the #159 unset of `GO111MODULE`, invoking as `GIMME_DEBUG=3 GO111MODULE=on gimme master` reveals all the `use of internal package` complaints which show that building Go itself is incompatible with having `GO111MODULE` set in environ.