### PR TITLE
Support installing the previous stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ To install and use the current stable release of Go:
 gimme stable
 ```
 
+To install the previous minor release of Go:
+
+``` bash
+gimme oldstable
+```
+
 Or to install and use the development version (master branch) of Go:
 
 ``` bash
@@ -163,12 +169,14 @@ versions and point Gimme at that instead.
 
 Invoke `gimme -k` or `gimme --known` to have Gimme report the versions which
 can be installed; invoking `gimme stable` installs the version which the Go
-Maintainers have declared to be stable.  Both of these involve making
-network requests to retrieve this information, although the `--known` output
-is cached.  (Use `--force-known-update` to ignore the cache).
+Maintainers have declared to be stable, and `gimme oldstable` installs the last
+stable release one minor version before the current stable. Both of these
+involve making network requests to retrieve this information, although the
+`--known` output is cached.  (Use `--force-known-update` to ignore the cache).
 
 The `stable` request retrieves <https://golang.org/VERSION?m=text> and reports
-that.
+that. The `oldstable` request does the same and downgrades it by one minor
+version.
 
 The `known` request retrieves <https://golang.org/dl> and parses the page to
 find releases.  This is not the same as the location where the images are
@@ -187,10 +195,11 @@ available.
 To make this easier, and reduce duplicate invocations, Gimme now supports a
 "query" which, instead of producing normal output, just prints the resolution
 of a version specifier.  This is the `--resolve` option.  It handles the `.x`
-suffix and the `stable` string; all other inputs are passed through unchanged,
-although unknown names will be accompanied by an error message and an exit
-code of 2.  A valid version identifier, even if not currently downloadable
-from upstream, will resolve successfully.  "Can resolve" is not "exists".
+suffix, the `stable` string, and the `oldstable` string; all other inputs are
+passed through unchanged, although unknown names will be accompanied by an
+error message and an exit code of 2.  A valid version identifier, even if not
+currently downloadable from upstream, will resolve successfully.  "Can resolve"
+is not "exists".
 
 Thus given a list of versions to invoke against, tooling might do a first pass
 to use `--resolve` on each and de-duplicate, so that if an alias and a

--- a/gimme
+++ b/gimme
@@ -589,8 +589,8 @@ _resolve_version() {
 		_get_curr_stable
 		return 0
 		;;
-	previous)
-		_get_prev_stable
+	oldstable)
+		_get_old_stable
 		return 0
 		;;
 	tip)
@@ -650,14 +650,14 @@ _get_curr_stable() {
 	cat "${stable}"
 }
 
-_get_prev_stable() {
-	local previous="${GIMME_VERSION_PREFIX}/previous"
+_get_old_stable() {
+	local oldstable="${GIMME_VERSION_PREFIX}/oldstable"
 
-	if _file_older_than_secs "${previous}" 86400; then
-		_update_previous "${previous}"
+	if _file_older_than_secs "${oldstable}" 86400; then
+		_update_oldstable "${oldstable}"
 	fi
 
-	cat "${previous}"
+	cat "${oldstable}"
 }
 
 _update_stable() {
@@ -669,14 +669,14 @@ _update_stable() {
 	rm -f "${stable}.old"
 }
 
-_update_previous() {
-	local previous="${1}"
-	local prev_x
-	prev_x=$(_get_curr_stable | awk -F. '{
+_update_oldstable() {
+	local oldstable="${1}"
+	local oldstable_x
+	oldstable_x=$(_get_curr_stable | awk -F. '{
 		$2--;
 		print $1 "." $2 "." "x"
 	}')
-	_resolve_version "${prev_x}" >"${previous}"
+	_resolve_version "${oldstable_x}" >"${oldstable}"
 }
 
 _last_mod_timestamp() {
@@ -902,7 +902,7 @@ esac
 
 case "${GIMME_GO_VERSION}" in
 stable) GIMME_GO_VERSION=$(_get_curr_stable) ;;
-previous) GIMME_GO_VERSION=$(_get_prev_stable) ;;
+oldstable) GIMME_GO_VERSION=$(_get_old_stable) ;;
 esac
 
 _assert_version_given "$@"

--- a/gimme
+++ b/gimme
@@ -589,6 +589,10 @@ _resolve_version() {
 		_get_curr_stable
 		return 0
 		;;
+	previous)
+		_get_prev_stable
+		return 0
+		;;
 	tip)
 		echo "tip"
 		return 0
@@ -646,6 +650,16 @@ _get_curr_stable() {
 	cat "${stable}"
 }
 
+_get_prev_stable() {
+	local previous="${GIMME_VERSION_PREFIX}/previous"
+
+	if _file_older_than_secs "${previous}" 86400; then
+		_update_previous "${previous}"
+	fi
+
+	cat "${previous}"
+}
+
 _update_stable() {
 	local stable="${1}"
 	local url="https://golang.org/VERSION?m=text"
@@ -653,6 +667,16 @@ _update_stable() {
 	_do_curl "${url}" "${stable}"
 	sed -i.old -e 's/^go\(.*\)/\1/' "${stable}"
 	rm -f "${stable}.old"
+}
+
+_update_previous() {
+	local previous="${1}"
+	local prev_x
+	prev_x=$(_get_curr_stable | awk -F. '{
+		$2--;
+		print $1 "." $2 "." "x"
+	}')
+	_resolve_version "${prev_x}" >"${previous}"
 }
 
 _last_mod_timestamp() {
@@ -876,9 +900,10 @@ arm64) ;;
 arm*) GIMME_HOSTARCH=arm ;;
 esac
 
-if [[ "${GIMME_GO_VERSION}" == "stable" ]]; then
-	GIMME_GO_VERSION=$(_get_curr_stable)
-fi
+case "${GIMME_GO_VERSION}" in
+stable) GIMME_GO_VERSION=$(_get_curr_stable) ;;
+previous) GIMME_GO_VERSION=$(_get_prev_stable) ;;
+esac
 
 _assert_version_given "$@"
 


### PR DESCRIPTION
This adds support for installing the previous stable release of Go with
`gimme oldstable`.

Coupled with `gimme stable`, this will make it possible for projects to easily
support the current and previous stable releases of Go. This matches
[Go's Release Policy][1]: the current and previous stable releases are
supported until a new Go release comes along.

  [1]: https://golang.org/doc/devel/release.html#policy

Users should be able to add `go: [oldstable, stable]` to their .travis.yml
once this is released.