### PR TITLE
Fix `_list_version` when there is no active version

### DIFF
--- a/gimme
+++ b/gimme
@@ -520,9 +520,12 @@ _list_versions() {
 	fi
 
 	local current_version
-	current_version="$(go env GOROOT 2>/dev/null)"
-	current_version="${current_version##*/go}"
-	current_version="${current_version%%.${GIMME_OS}.*}"
+
+	if command -v go &>/dev/null; then
+		current_version="$(go env GOROOT 2>/dev/null)"
+		current_version="${current_version##*/go}"
+		current_version="${current_version%%.${GIMME_OS}.*}"
+	fi
 
 	# 1.1 1.10 1.2 is bad; zsh has `setopt numeric_glob_sort` but bash
 	# doesn't appear to have anything like that.


### PR DESCRIPTION
When there's no currently active go version (no `go` command found in `$PATH`), `_list_versions` returns error 127 (command not found) when trying to extract the current go version (by executing `go` binary without any checks).

`gimme -l` (`_list_versions`) should always work, regardless of the state of any (in)active go. This is specially true when trying to check if a specific version is installed before any version is activated.