### PR TITLE
Use empty GOFLGAS when checking go version

### DIFF
--- a/gimme
+++ b/gimme
@@ -359,7 +359,7 @@ _env() {
 
 	# if we try to run a Darwin binary on Linux, we need to fail so 'auto' can fallback to cross-compiling from source
 	# automatically
-	GOROOT="${1}" "${1}/bin/go" version &>/dev/null || return 1
+	GOROOT="${1}" GOFLAGS="" "${1}/bin/go" version &>/dev/null || return 1
 
 	# https://twitter.com/davecheney/status/431581286918934528
 	# we have to GOROOT sometimes because we use official release binaries in unofficial locations :(


### PR DESCRIPTION
When checking `go version` output, reset `$GOFLAGS` value to empty, as
it can cause problems even if it's set to a bad value.