### PR TITLE
Check if the known-versions.txt exists and is not empty

### DIFF
--- a/gimme
+++ b/gimme
@@ -545,7 +545,7 @@ _update_remote_known_list_if_needed() {
 	local list="${GIMME_VERSION_PREFIX}/known-versions.txt"
 	local dlfile="${GIMME_TMP}/known-dl"
 
-	if [[ -e "${list}" ]] &&
+	if [[ -s "${list}" ]] &&
 		! ((force_known_update)) &&
 		! _file_older_than_secs "${list}" "${GIMME_KNOWN_CACHE_MAX}"; then
 		echo "${list}"


### PR DESCRIPTION
When gimme is unable to download or parse the versions list, it can end up creating an empty `known-versions.txt` file. 

This PR modifies the update condition to check if the file has size greater than zero

