### PR TITLE
replace the GIMME_DOWNLOAD_BASE URL

### DIFF
--- a/gimme
+++ b/gimme
@@ -785,7 +785,7 @@ _to_goarch() {
 : "${GIMME_GO_GIT_REMOTE:=https://github.com/golang/go.git}"
 : "${GIMME_TYPE:=auto}" # 'auto', 'binary', 'source', or 'git'
 : "${GIMME_BINARY_OSX:=osx10.8}"
-: "${GIMME_DOWNLOAD_BASE:=https://storage.googleapis.com/golang}"
+: "${GIMME_DOWNLOAD_BASE:=https://dl.google.com/go}"
 : "${GIMME_LIST_KNOWN:=https://golang.org/dl}"
 : "${GIMME_KNOWN_CACHE_MAX:=10800}"
 


### PR DESCRIPTION
On April 16th, the permissions on the `storage.googleapis.com/golang` storage were changed leading to a global impossibility to download go from this storage. (See https://github.com/golang/go/issues/45603). This led to the `gimme` script to not be working anymore.

The actual golang website is using `https://dl.google.com/go` as the base, and this URL was not unavailable during yesterday's issue.

I suggest with this PR that we change this URL to use the one that the Golang website advertises and uses (https://golang.org/dl/).

cc @FiloSottile who can probably 👍  from a Google POV.