### PR TITLE
Support for bootstrapping with Go 1.17

### DIFF
--- a/gimme
+++ b/gimme
@@ -285,7 +285,7 @@ _extract() {
 
 # _setup_bootstrap
 _setup_bootstrap() {
-	local versions=("1.16" "1.15" "1.14" "1.13" "1.12" "1.11" "1.10" "1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
+	local versions=("1.17" "1.16" "1.15" "1.14" "1.13" "1.12" "1.11" "1.10" "1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
 
 	# try existing
 	for v in "${versions[@]}"; do


### PR DESCRIPTION
I know it's still a release candidate, but the final release is just
around the corner, let's be ready for it :D

Also noticed that soon the list will need to be reviewed, as Go move
away from bootstrapping with Go 1.4 (see golang/go#44505)