### PR TITLE
Allow for gimme -l to work with no go version available on the path

### DIFF
--- a/gimme
+++ b/gimme
@@ -520,7 +520,7 @@ _list_versions() {
 	fi
 
 	local current_version
-	current_version="$(go env GOROOT 2>/dev/null)"
+	current_version="$(go env GOROOT 2>/dev/null || true)"
 	current_version="${current_version##*/go}"
 	current_version="${current_version%%.${GIMME_OS}.*}"
 


### PR DESCRIPTION
I think that this should address [this](https://github.com/travis-ci/gimme/issues/172) issue. I could not figure out how to run the tests locally, so I can't guarantee that they will pass yet.